### PR TITLE
Stop shadowing primitive types, clean up imports and fully qualified imports

### DIFF
--- a/src/gbor.gleam
+++ b/src/gbor.gleam
@@ -1,12 +1,15 @@
 pub type CBOR {
-  Int(Int)
-  String(String)
-  Float(Float)
-  Map(List(#(CBOR, CBOR)))
-  Array(List(CBOR))
-  Bool(Bool)
-  Null
-  Undefined
-  Binary(BitArray)
-  Tagged(Int, CBOR)
+  CBInt(Int)
+  CBString(String)
+  CBFloat(Float)
+  CBMap(List(#(CBOR, CBOR)))
+  CBArray(List(CBOR))
+  CBBool(Bool)
+  CBNull
+  CBUndefined
+  CBBinary(BitArray)
+  CBTagged(Int, CBOR)
 }
+
+// Placeholder for LSP
+pub const a = Nil


### PR DESCRIPTION
Probably better not to stomp on the native primitive variants, and use a prefix. I opted for CB but anything would work. Also, I cleaned up the imports to explicitly show they are imports with a prefix char. Let me know what you think. 