### PR TITLE
Add conversion to/from gleam types for CBOR tags 1-4

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,6 +9,7 @@ repository = { type = "github", user = "Beaudidly", repo = "gbor" }
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 ieee_float = ">= 1.5.0 and < 2.0.0"
 gleam_erlang = ">= 1.2.0 and < 2.0.0"
+gleam_time = ">= 1.3.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/src/gbor.gleam
+++ b/src/gbor.gleam
@@ -7,6 +7,8 @@
 /// > **Note**: This type may become opaque in future major types as we evaluate
 /// > the API needs for this package.
 ///
+import gleam/time/timestamp.{type Timestamp}
+
 pub type CBOR {
   CBInt(Int)
   CBString(String)
@@ -18,6 +20,7 @@ pub type CBOR {
   CBUndefined
   CBBinary(BitArray)
   CBTagged(Int, CBOR)
+  CBTime(Timestamp)
 }
 
 // Placeholder for LSP


### PR DESCRIPTION
This PR will decode time tags (1,2) and bignum (3,4) to gleam Timestamp ([gleam_time](https://hexdocs.pm/gleam_time/) type) and Int respectively. It will also encode Timestamps to tag 0 (only) and bignum integers to tag 3 or 4.
This is a proposal that may need some more thought and should maybe not be included the 1.0 release?  